### PR TITLE
Problem with long disk path

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -483,7 +483,7 @@ fi
 if [ $EXECUTE = 1 ]; then
 	MKVFILESIZE=$($DUCMD "$MKVFILE" | cut -f1)
 	AC3FILESIZE=$($DUCMD "$AC3FILE" | cut -f1)
-	WDFREESPACE=$(\df -k "$WD" | tail -1 | awk '{print $4*1024}')
+	WDFREESPACE=$(\df -Pk "$WD" | tail -1 | awk '{print $4*1024}')
 	if [ $(($MKVFILESIZE + $AC3FILESIZE)) -gt $WDFREESPACE ]; then
 		error "ERROR: There is not enough free space on \"$WD\" to create the new file."
 		exit 1


### PR DESCRIPTION
As I mounting my disk using UUID I got a problem with to long path; so df broke the line after path and the script calculated the wrong free space.

with the option -P (POSIX output) it works for me; and hopefully for others.
