### PR TITLE
Fix problems when running in non-English locales

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -48,6 +48,9 @@ if [ -f ~/.mkvdts2ac3.rc ]; then
 	. ~/.mkvdts2ac3.rc
 fi
 
+# Force English, mkvinfo may fail otherwise
+export LC_ALL=C
+
 #---------- FUNCTIONS --------
 displayhelp() {
 # Usage: displayhelp


### PR DESCRIPTION
mkvdts2ac3 has been broken for several months for me, and when I dig into it I found out the problem: the DTS track ID wasn't being correctly extracted, because _mkvmerge -i_ was now localized in Spanish. Forcing all mkvdts2ac3 to run in English solves the problem.
