### PR TITLE
Script doesn't work when file path contains non-ASCII characters

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -48,8 +48,8 @@ if [ -f ~/.mkvdts2ac3.rc ]; then
 	. ~/.mkvdts2ac3.rc
 fi
 
-# Force English, mkvinfo may fail otherwise
-export LC_ALL=C
+# Force English output, grepping for messages may fail otherwise
+export LC_MESSAGES=C
 
 #---------- FUNCTIONS --------
 displayhelp() {


### PR DESCRIPTION
I've discovered that my previous commit broke the script whenever the file path contained non-ASCII characters. This commit fixes it.
