### PR TITLE
Restrict track info to actual track

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -422,12 +422,22 @@ fi
 # Get the specified DTS track's information
 doprint ""
 doprint $"Extract track information for selected DTS track."
-doprint "> mkvinfo \"$MKVFILE\" | grep -A 25 \"Track number: $DTSTRACK\""
+doprint "> mkvinfo \"$MKVFILE\"" 
 
 INFO=$"INFO" #Value for debugging
 dopause
 if [ $EXECUTE = 1 ]; then
-	INFO=$(mkvinfo "$MKVFILE" | grep -A 25 "Track number: $DTSTRACK")
+	INFO=$(mkvinfo "$MKVFILE")
+	FIRSTLINE=$(echo "$INFO" | grep -n "Track number: $DTSTRACK" | cut -d ":" -f 1)
+	INFO=$(echo "$INFO" | tail -n +$FIRSTLINE)
+	LASTLINE=$(echo "$INFO" | grep -n "Track number: $(($DTSTRACK+1))" | cut -d ":" -f 1)
+	if [ -z "$LASTLINE" ]; then
+		LASTLINE=$(echo "$INFO" | grep -m 1 -n "|+" | cut -d ":" -f 1)
+	fi
+	if [ -z "$LASTLINE" ]; then
+		LASTLINE=$(echo "$INFO" | wc -l)
+	fi
+	INFO=$(echo "$INFO" | head -n $LASTLINE)
 fi
 
 #Get the language for the DTS track specified


### PR DESCRIPTION
You're now looking at the 25 lines after the DTS track info starts. You should look instead at the actual track info.

This prevents a bug I've bumped into a couple of times. When DTS track language info is missing (implied to be English), but the 25 lines contain chapter language info, the language detection code breaks (because indentation for chapter language info is different).

I can also imagine another scenario with the same DTS English track with no language info and a second non-English track within the 25 lines. Language detection would then wrongly use the non-English language info for the AC3 track.
