### PR TITLE
Fixed 4 Minor Bugs & Prettified Output

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -161,7 +161,7 @@ cleanup() {
 	if [ -f $1 ]; then
 		rm $1
 		if [ $? -ne 0 ]; then
-			$"There was a problem removing the file \"$1\".  Please remove manually."
+			$"There was a problem removing the file \"$1\". Please remove manually."
 			return 1
 		fi
 	fi
@@ -225,7 +225,7 @@ while [ -z "$MKVFILE" ]; do
 			KEEPDTS=0
 			DEFAULT=0
 		;;
-		"-f" | "--force" ) # Test for AC3 track exits immediately.  Use this to continue
+		"-f" | "--force" ) # Test for AC3 track exits immediately. Use this to continue
 			FORCE=1
 		;;
 		"-i" | "--initial" ) # Make new AC3 track the first in the file
@@ -356,9 +356,10 @@ if [ $EXECUTE = 1 ]; then
 	checkdep perl
 fi
 
-# Added check to see if AC3 track exists.  If so, no need to continue
+# Added check to see if AC3 track exists. If so, no need to continue
 if [ "$(mkvmerge -i "$MKVFILE" | grep -i "A_AC3")" ]; then
 	echo $"AC3 track already exists in '$MKVFILE'."
+	echo ""
 	if [ $FORCE = 0 ]; then
 		info $"Use -f or --force argument to bypass this check."
 		exit 1
@@ -405,6 +406,7 @@ if [ -z $DTSTRACK ]; then
 	doprint "RESULT:DTSTRACK=$DTSTRACK"
 else
 	# Checks to make sure the command line argument track id is valid
+	doprint ""
 	doprint $"Checking to see if DTS track specified via arguments is valid."
 	doprint "> mkvmerge -i \"$MKVFILE\" | grep \"Track ID $DTSTRACK: audio (A_DTS)\""
 	VALID=$"VALID" #Value for debugging
@@ -441,7 +443,7 @@ if [ $EXECUTE = 1 ]; then
 	fi
 	INFO=$(echo "$INFO" | head -n $LASTLINE)
 fi
-doprint "RESULT:INFO=$INFO"
+doprint "RESULT:INFO=\n$INFO"
 
 #Get the language for the DTS track specified
 doprint ""
@@ -513,7 +515,7 @@ dopause
 if [ $EXECUTE = 1 ]; then
 	color YELLOW; echo $"Converting DTS to AC3:"; color OFF
 	DTSFILESIZE=$($DUCMD "$DTSFILE" | cut -f1) # Capture DTS filesize for end summary
-	nice -n $PRIORITY ffmpeg -i "$DTSFILE" -acodec ac3 -ac 6 -ab 448k "$AC3FILE" 2>&1|perl -ne '$/="\015";next unless /size=\s*(\d+)/;$|=1;$s='$DTSFILESIZE';printf "Progress: %.0f%\r",450*$1/$s'   #run ffmpeg and only show Progress %.  Need perl to read \r end of lines
+	nice -n $PRIORITY ffmpeg -i "$DTSFILE" -acodec ac3 -ac 6 -ab 448k "$AC3FILE" 2>&1|perl -ne '$/="\015";next unless /size=\s*(\d+)/;$|=1;$s='$DTSFILESIZE';printf "Progress: %.0f%\r",450*$1/$s' #run ffmpeg and only show Progress %. Need perl to read \r end of lines
 	checkerror $? $"Converting the DTS file to AC3 failed" 1
 
 	# If we are keeping the DTS track external copy it back to original folder before deleting
@@ -547,7 +549,7 @@ if [ $EXTERNAL ]; then
 	MKVFILE="$DEST/$NAME.ac3"
 else
 	# Start to "build" command
-	CMD="nice -n $PRIORITY mkvmerge "
+	CMD="nice -n $PRIORITY mkvmerge"
 
 	# Puts the AC3 track as the second in the file if indicated as initial
 	if [ $INITIAL = 1 ]; then
@@ -611,7 +613,6 @@ else
 
 	# ------ MUXING ------
 	# Run it!
-	doprint ""
 	doprint $"Running main remux."
 	doprint "> $CMD"
 	dopause
@@ -683,7 +684,7 @@ else
 			OLDFILEMD5=$(md5sum "$NEWFILE" | cut -d" " -f1)
 			NEWFILEMD5=$(md5sum "$MKVFILE" | cut -d" " -f1)
 			if [ $OLDFILEMD5 -ne $NEWFILEMD5 ]; then
-				error $"'$NEWFILE' and '$MKVFILE' files do not match.  You might want to investigate!"
+				error $"'$NEWFILE' and '$MKVFILE' files do not match. You might want to investigate!"
 			fi
 		fi
 	fi


### PR DESCRIPTION
#### [Use the default value "eng" if the "language" element itself is not present in the file.](https://github.com/1951FDG/mkvdts2ac3/commit/3bd48330eaa141c1081aacf3569693a85879cd4f)

Starting with version 4.0.0 mkvmerge does not write elements to output files whose value equals their default value. mkvinfo only lists elements that are actually present in the file. If a track does not contain a "language" element then the default value "eng" must be used by mkvdts2ac3.

"eng" is the default value for the "language" element.

**Before fix:**
DTSLANG=
(output_file) - Language: und

**After fix:**
DTSLANG=eng
(output_file) - Language: eng
#### [Added missing line "color OFF" at the end of info()](https://github.com/1951FDG/mkvdts2ac3/commit/2631152848becbce0038cba90996a383b4aeb423)

**Before fix:**
blue colored output until color YELLOW called

**After fix:**
blue colored output terminated upon end of info()
#### [Standard Practice](https://github.com/1951FDG/mkvdts2ac3/commit/6954d57dbe5960657dd8fa05cbdc4730d145a3e9)

The value "VALID" for debugging was not defined beforehand like other debugging values.

**Before fix:**
if (--test), RESULT:VALID=

**After fix:**
if (--test), RESULT:VALID=VALID
#### ["ERROR: " was mentioned twice](https://github.com/1951FDG/mkvdts2ac3/commit/348e5ee975101851dba5ac42bb7002151d809e7d)

"ERROR: " already present in error(), duplicate text removed to prettify output
#### ["RESULT:DTSLANG=$DTSLANG" -> "RESULT:DTSNAME=$DTSNAME"](https://github.com/1951FDG/mkvdts2ac3/commit/aa75906c6d41b26ebbaf23b0c028c459e00c92d7)

The value "DTSLANG" for debugging was shown twice and the value "DTSNAME" for debugging was not shown.

**Before fix:**
if (--test), RESULT:DTSLANG=$DTSLANG, RESULT:DTSLANG=$DTSLANG

**After fix:**
if (--test), RESULT:DTSLANG=$DTSLANG, RESULT:DTSNAME=$DTSNAME
#### [Use info() for several alerts](https://github.com/1951FDG/mkvdts2ac3/commit/e4bfc25e91f7482787caf39174c8b06e6d5a8a28)

Used info instead of echo for "Use -f or --force argument to bypass this check." && "Force mode is on. Continuing..."

Also used info for "Moving new file over old file. DO NOT KILL THIS PROCESS OR YOU WILL EXPERIENCE DATA LOSS!" && "Moving new file over old file. DO NOT KILL THIS PROCESS OR YOU WILL EXPERIENCE DATA LOSS!"

color YELLOW is not very readable and color BLUE stands out more making it highly distracting to the eye thus demanding attention.
#### [Standardization (doprint -> doprint "")](https://github.com/1951FDG/mkvdts2ac3/commit/d2410c0f6cdc3bb0b3b27b63d034789733846961)

Standardization, nothing more to mention...
#### [Prettify output](https://github.com/1951FDG/mkvdts2ac3/commit/36eba855b31fa390bee7762b2c2e49840351c97c)

Removed extra spaces, added echo "", added/removed doprint "" where needed, and added a newline to RESULT:INFO=\n$INFO to prettify output (more easily readable output).
