### PR TITLE
Execute "GATHER DATA" when using --test

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -432,9 +432,9 @@ INFO=$"INFO" #Value for debugging
 dopause
 if [ $EXECUTE = 1 ] || [ $PRINT = 1 ]; then
 	INFO=$(mkvinfo "$MKVFILE")
-	FIRSTLINE=$(echo "$INFO" | grep -n -m 1 "Track number: $DTSTRACK" | cut -d ":" -f 1)
+	FIRSTLINE=$(echo "$INFO" | grep -n -m 1 "Track number: $(($DTSTRACK+1))" | cut -d ":" -f 1)
 	INFO=$(echo "$INFO" | tail -n +$FIRSTLINE)
-	LASTLINE=$(echo "$INFO" | grep -n -m 1 "Track number: $(($DTSTRACK+1))" | cut -d ":" -f 1)
+	LASTLINE=$(echo "$INFO" | grep -n -m 1 "Track number: $(($DTSTRACK+2))" | cut -d ":" -f 1)
 	if [ -z "$LASTLINE" ]; then
 		LASTLINE=$(echo "$INFO" | grep -m 1 -n "|+" | cut -d ":" -f 1)
 	fi


### PR DESCRIPTION
#### [Execute "GATHER DATA" when $PRINT is set to 1.](https://github.com/1951FDG/mkvdts2ac3/commit/ec88306802739eeed0bab3d476c714f9a3c59cdb)

**Before fix:**
population of `$DTSTRACK`, `$VALID`, `$INFO`, `$DTSLANG`, `$DTSNAME`: false

**After fix:**
population of `$DTSTRACK`, `$VALID`, `$INFO`, `$DTSLANG`, `$DTSNAME`: true
### [Fix regular expression for gsub()](https://github.com/1951FDG/mkvdts2ac3/commit/a044afb106454546a490639688a83d653c82e9a6)

**Before fix:**
English DTS 5.1 @ 1.5 Mbps -> English AC3 5.1 @ 1.5 Mbps

**After fix:**
English DTS 5.1 @ 1.5 Mbps -> English AC3 5.1 @ 448 Kbps
### [Fix track number for mkvinfo](https://github.com/1951FDG/mkvdts2ac3/commit/ee1189a4be37e1ff8ee75e4ce3b0955de2feb664)

mkvmerge lists track numbers starting at 0 but mkvinfo lists track numbers starting at 1! [more info](https://trac.bunkus.org/ticket/689)
