### PR TITLE
Only match numbers in mkvtoolnix version check

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -357,8 +357,8 @@ if [ $EXECUTE = 1 ]; then
 fi
 
 # Make some adjustments based on the version of mkvtoolnix
-MKVTOOLNIXVERSION=$(mkvmerge -V | cut -d " " -f 2 | sed s/\\.//g)
-if [ ${MKVTOOLNIXVERSION:1} -lt 670 ]; then
+MKVTOOLNIXVERSION=$(mkvmerge -V | cut -d " " -f 2 | sed s/\[\^0-9\]//g)
+if [ ${MKVTOOLNIXVERSION} -lt 670 ]; then
 	AUDIOTRACKPREFIX="audio (A_"
 	VIDEOTRACKPREFIX="video (V_"
 else


### PR DESCRIPTION
Some versions of mkvmerge return "v7.0.0" as the version number. With the old sed
matcher, the "v" in the expression was not filtered out and therefore the
wrong audio and video track prefixes would be used. Now only alpha–numeric
characters are returned.
