### PR TITLE
AC3 track should come after video

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -563,7 +563,7 @@ else
 
 	# Puts the AC3 track as the second in the file if indicated as initial
 	if [ $INITIAL = 1 ]; then
-		CMD="$CMD --track-order 0:1,1:0"
+		CMD="$CMD --track-order 0:0,1:0"
 	fi
 
 	# Declare output file


### PR DESCRIPTION
Incorrectly used "0:1" as first argument to `--track-order` which puts the AC3 track first instead of video.