### PR TITLE
Fix for always failing AC3 track detection

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -367,7 +367,7 @@ else
 fi
 
 # Added check to see if AC3 track exists. If so, no need to continue
-if [ "$(mkvmerge -i "$MKVFILE" | grep -i "${AUDIOTRACKPREFIX}AC3")" ]; then
+if [ "$(mkvmerge -i "$MKVFILE" | grep -i "${AUDIOTRACKPREFIX}AC-3")" ]; then
 	echo $"AC3 track already exists in '$MKVFILE'."
 	echo ""
 	if [ $FORCE = 0 ]; then


### PR DESCRIPTION
At some point, `mkvmerge` changed the output of AC3 track info to be `AC-3` vs `AC3` so the original grep statement always failed. This is a simple fix.