### PR TITLE
fix initial option to make the AC3 track the first audio track

### DIFF
--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -475,11 +475,11 @@ if [ -z $DTSNAME ]; then
 	# Get the name for the DTS track specified
 	doprint ""
 	doprint $"Extract name for selected DTS track. Change DTS to AC3 and update bitrate if present."
-	doprint '> echo "$INFO" | grep -m 1 "Name" | cut -d " " -f 5- | sed "s/DTS/AC3/" | awk '"'{gsub(/[0-9]+(\.[0-9]+)?(M|K)bps/,"448Kbps")}1'"''
+	doprint '> echo "$INFO" | grep -m 1 "Name" | cut -d " " -f 5- | sed "s/DTS/AC3/" | awk '"'{gsub(/[0-9]+(\.[0-9]+)?(M|K)bps/,"640Kbps")}1'"''
 	DTSNAME="DTSNAME" #Value for debugging
 	dopause
 	if [ $EXECUTE = 1 ]; then
-		DTSNAME=$(echo "$INFO" | grep -m 1 "Name" | cut -d " " -f 5- | sed "s/DTS/AC3/" | awk '{gsub(/[0-9]+(\.[0-9]+)?(M|K)bps/,"448Kbps")}1')
+		DTSNAME=$(echo "$INFO" | grep -m 1 "Name" | cut -d " " -f 5- | sed "s/DTS/AC3/" | awk '{gsub(/[0-9]+(\.[0-9]+)?(M|K)bps/,"640Kbps")}1')
 	fi
 	doprint "RESULT:DTSNAME=$DTSNAME"
 fi
@@ -519,13 +519,13 @@ fi
 # ------ CONVERSION ------
 # Convert DTS to AC3
 doprint $"Converting DTS to AC3."
-doprint "> ffmpeg -i \"$DTSFILE\" -acodec ac3 -ac 6 -ab 448k \"$AC3FILE\""
+doprint "> ffmpeg -i \"$DTSFILE\" -acodec ac3 -ac 6 -ab 640k \"$AC3FILE\""
 
 dopause
 if [ $EXECUTE = 1 ]; then
 	color YELLOW; echo $"Converting DTS to AC3:"; color OFF
 	DTSFILESIZE=$($DUCMD "$DTSFILE" | cut -f1) # Capture DTS filesize for end summary
-	nice -n $PRIORITY ffmpeg -i "$DTSFILE" -acodec ac3 -ac 6 -ab 448k "$AC3FILE" 2>&1|perl -ne '$/="\015";next unless /size=\s*(\d+)/;$|=1;$s='$DTSFILESIZE';printf "Progress: %.0f%\r",450*$1/$s' #run ffmpeg and only show Progress %. Need perl to read \r end of lines
+	nice -n $PRIORITY ffmpeg -i "$DTSFILE" -acodec ac3 -ac 6 -ab 640k "$AC3FILE" 2>&1|perl -ne '$/="\015";next unless /size=\s*(\d+)/;$|=1;$s='$DTSFILESIZE';printf "Progress: %.0f%\r",450*$1/$s' #run ffmpeg and only show Progress %. Need perl to read \r end of lines
 	checkerror $? $"Converting the DTS file to AC3 failed" 1
 
 	# If we are keeping the DTS track external copy it back to original folder before deleting

--- a/mkvdts2ac3.sh
+++ b/mkvdts2ac3.sh
@@ -66,7 +66,7 @@ displayhelp() {
 	echo "                      original matroska file. This overrides '-n' and"
 	echo "                      '-d' arguments."
 	echo "     -f, --force      Force processing when AC3 track is detected"
-	echo "     -i, --initial    New AC3 track will be first in the file."
+	echo "     -i, --initial    New AC3 track will be first audio track in the file."
 	echo "     -k, --keep-dts   Keep external DTS track (implies '-n')."
 	echo "     -m, --nocolor    Do not use colors (monotone)."
 	echo "     --md5            Perform MD5 comparison when copying across drives."
@@ -561,9 +561,9 @@ else
 	# Start to "build" command
 	CMD="nice -n $PRIORITY mkvmerge"
 
-	# Puts the AC3 track as the second in the file if indicated as initial
+	# Puts the AC3 track as the first audio track in the file if indicated as initial
 	if [ $INITIAL = 1 ]; then
-		CMD="$CMD --track-order 0:1,1:0"
+		CMD="$CMD --track-order 0:0,1:0"
 	fi
 
 	# Declare output file


### PR DESCRIPTION
The initial option doesn't work properly.  From my reading, it should make the AC3 track the first audio track in the file.

For example your test mkv file has track 1 as the video and track 2 as the DTS audio, the --initial option should put the new AC3 track as track 2, and shunt the DTS track to 3.  The video should stay as track 1.  This doesn't happen.

Currently if you use --initial on your test mkv file you end up with the DTS track as track 1, the AC3 track as track 2 and the video track as track 3!  This confuses some players like my TV.

This fix makes the AC3 track the first audio track in the file when using the --initial option.